### PR TITLE
Fix Security Vulnerabilities

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -208,7 +208,8 @@
       "integrity": "sha1-wN3kqxgnE7kZuXCVmhI+zBow/NY="
     },
     "clean-css": {
-      "version": "3.4.28",
+//      "version": "3.4.28",
+      "version": "4.1.11",
       "resolved": "https://registry.npmjs.org/clean-css/-/clean-css-3.4.28.tgz",
       "integrity": "sha1-vxlF6C/ICPVWlebd6uwBQA79A/8=",
       "requires": {
@@ -298,7 +299,8 @@
       }
     },
     "constantinople": {
-      "version": "3.0.2",
+//      "version": "3.0.2",
+      "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/constantinople/-/constantinople-3.0.2.tgz",
       "integrity": "sha1-S5RdmTeQe82Y7ldRIsOBdRZUQUE=",
       "requires": {
@@ -872,7 +874,8 @@
       "integrity": "sha1-nIDlOMEtP7lcjZu5VZ+gzAQEBf0=",
       "requires": {
         "character-parser": "1.2.1",
-        "clean-css": "^3.1.9",
+//        "clean-css": "^3.1.9",
+        "clean-css": "^4.1.11",
         "commander": "~2.6.0",
         "constantinople": "~3.0.1",
         "jstransformer": "0.0.2",


### PR DESCRIPTION
WS-2018-0068 More information
high severity
Vulnerable versions: < 3.1.1
Patched version: 3.1.1
Versions of constantinople prior to 3.1.1 are vulnerable to a sandbox bypass which can lead to arbitrary code execution.

WS-2019-0017 More information
moderate severity
Vulnerable versions: < 4.1.11
Patched version: 4.1.11
Version of clean-css prior to 4.1.11 are vulnerable to Regular Expression Denial of Service (ReDoS). Untrusted input may cause catastrophic backtracking while matching regular expressions. This can cause the application to be unresponsive leading to Denial of Service.
